### PR TITLE
Fixed exit() to avoid error NameError: name 'exit' is not defined

### DIFF
--- a/tools/apollo3_scripts/uart_wired_update.py
+++ b/tools/apollo3_scripts/uart_wired_update.py
@@ -176,7 +176,7 @@ def connect_device(ser):
         print("Length = ", hex(word >> 16))
         print([hex(n) for n in response])
         print("!!!Wired Upgrade Unsuccessful!!!....Terminating the script")
-        exit()
+        sys.exit()
 
 #******************************************************************************
 #
@@ -205,10 +205,10 @@ def send_ackd_command(command, ser):
                 break
         else:
             print("!!!Wired Upgrade Unsuccessful!!!....unexpected respose - Terminating the script")
-            exit()
+            sys.exit()
     if (numTries == 4):
         print("!!!Wired Upgrade Unsuccessful!!!....numTries exceeded - Terminating the script")
-        exit()
+        sys.exit()
 
     return response
 


### PR DESCRIPTION
When the script fails due to Unknown message received, it will crash due to `exit()` not being properly defined.
Changed `exit()` to `sys.exit()`


```log
Connecting with Corvette over serial port /dev/cu.usbserial-210...
RESET RAK11720 BOARD!!!
Sending Hello.
Received response for Hello
Received Unknown Message
msgType =  0x7720
Length =  0x7469
Traceback (most recent call last):
  File "uart_wired_update.py", line 353, in <module>
['0x54', '0x65', '0x73', '0x74', '0x20', '0x77', '0x69', '0x74', '0x68', '0x20', '0x48', '0x49', '0x47', '0x48', '0x20', '0x61', '0x6e', '0x64', '0x20', '0x4c', '0x4f', '0x57', '0xd', '0xa', '0x53', '0x65', '0x74', '0x74', '0x69', '0x6e', '0x67', '0x20', '0x74', '0x6f', '0x20', '0x48', '0x49', '0x47', '0x48', '0x2c', '0x20', '0x61', '0x6e', '0x64', '0x20', '0x77', '0x61', '0x69', '0x74', '0x69', '0x6e', '0x67', '0x20', '0x35', '0x20', '0x73', '0x65', '0x63', '0x6f', '0x6e', '0x64', '0x73', '0xd', '0xa', '0x53', '0x65', '0x74', '0x74', '0x69', '0x6e', '0x67', '0x20', '0x74', '0x6f', '0x20', '0x4c', '0x4f', '0x57', '0x2c', '0x20', '0x61', '0x6e', '0x64', '0x20', '0x77', '0x61', '0x69', '0x74']
!!!Wired Upgrade Unsuccessful!!!....Terminating the script
  File "uart_wired_update.py", line 42, in main
  File "uart_wired_update.py", line 185, in connect_device
NameError: name 'exit' is not defined
[20556] Failed to execute script 'uart_wired_update' due to unhandled exception!
Failed to burn bootloader: uploading error: exit status 1
```